### PR TITLE
Youtube fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ export function render ({ props }) {
 }
 
 export function afterMount (component, el) {
-  if (!window.gapi) {
+  if (!window.gapi || !window.gapi.ytsubscribe) {
     console.error('deku-youtube-subscribe-button: Please add <script src="https://apis.google.com/js/platform.js"></script> to your html (before deku-youtube-subscribe-button is run)');
     return;
   }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "babel-cli": "^6.2.0",
     "babel-plugin-transform-react-jsx": "^6.1.18",
     "babel-preset-es2015": "^6.1.18",
-    "babel-tape-runner": "^1.3.0",
+    "babel-tape-runner": "^2.0.0",
     "deku": "^0.5.6",
     "semistandard-deku": "github:micnews/semistandard#deku",
     "snazzy": "^2.0.1",

--- a/test.js
+++ b/test.js
@@ -1,4 +1,3 @@
-'use strict';
 /** @jsx element */
 
 import test from 'tape';
@@ -17,6 +16,35 @@ test('simple youtube button', function (t) {
       <div class="g-ytsubscribe" data-channelid="myChannelId" data-layout="default" data-count="hidden" data-onytevent="youtubeSubscribeButtonEvent0"></div>
     </div>
   `);
+
+  t.end();
+});
+
+test('YoutubeSubscribeButton#afterMount', function (t) {
+  function _afterMount () {
+    return YoutubeSubscribeButton.afterMount({}, {});
+  }
+
+  GLOBAL.window = {};
+  t.equal(_afterMount(),
+    undefined,
+    'returns undefined if window.gapi is not present');
+
+  GLOBAL.window.gapi = {};
+  t.equal(_afterMount(),
+    undefined,
+    'returns undefined if window.gapi.ytsubscribe is not present');
+
+  let calledGo = false;
+  GLOBAL.window.gapi.ytsubscribe = {
+    go: function () {
+      calledGo = true;
+    }
+  };
+  _afterMount();
+
+  t.ok(calledGo,
+    'calls #go on ytsubcribe when present');
 
   t.end();
 });


### PR DESCRIPTION
There are instances where you can have window.gapi and not window.gapi.ytsubscribe. This keeps the component from throwing when that happens.

Also, needed to upgrade to babel-tape-runner v2 to get tests to run.
